### PR TITLE
ビルド時の警告除去

### DIFF
--- a/driver/ptx_chrdev.h
+++ b/driver/ptx_chrdev.h
@@ -124,6 +124,8 @@ int ptx_chrdev_context_create(const char *name, const char *devname,
 			      unsigned int total_num,
 			      struct ptx_chrdev_context **chrdev_ctx);
 void ptx_chrdev_context_destroy(struct ptx_chrdev_context *chrdev_ctx);
+int ptx_chrdev_context_reserve(struct ptx_chrdev_context *chrdev_ctx,
+			       unsigned int num, unsigned int *minor_base);
 int ptx_chrdev_context_add_group(struct ptx_chrdev_context *chrdev_ctx,
 				 struct device *dev,
 				 const struct ptx_chrdev_group_config *config,

--- a/driver/px4_usb.c
+++ b/driver/px4_usb.c
@@ -134,7 +134,7 @@ static int px4_usb_probe(struct usb_interface *intf,
 
 			dev_info(dev, "Multi-device power control: %s\n",
 				 (px4_use_mldev) ? "enabled" : "disabled");
-			/* fall through */
+			/* fall through */ fallthrough;
 		case USB_PID_PX_W3U4:
 		case USB_PID_PX_W3PE4:
 		case USB_PID_PX_W3PE5:
@@ -152,7 +152,7 @@ static int px4_usb_probe(struct usb_interface *intf,
 
 		case USB_PID_PX_MLT5U:
 			pxmlt5_model = PXMLT5U_MODEL;
-			/* fall through */
+			/* fall through */ fallthrough;
 		case USB_PID_PX_MLT5PE:
 			ret = px4_usb_init_bridge(dev, usb_dev,
 						  &ctx->ctx.pxmlt.it930x);
@@ -167,7 +167,7 @@ static int px4_usb_probe(struct usb_interface *intf,
 
 		case USB_PID_PX_MLT8PE3:
 			pxmlt8_model = PXMLT8PE3_MODEL;
-			/* fall through */
+			/* fall through */ fallthrough;
 		case USB_PID_PX_MLT8PE5:
 			ret = px4_usb_init_bridge(dev, usb_dev,
 						  &ctx->ctx.pxmlt.it930x);


### PR DESCRIPTION
- 関数のプロトタイプ宣言の欠如
- switch caseのfallthroughをマクロを使って明示する